### PR TITLE
Add basic HTML5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ You can adjust the HtmlPurifier configuration by passing in the config key into 
 ```
 You can find all the configurable options and custom filters on the http://htmlpurifier.org/ website.
 
+###HTML5 support
+
+HTMLPurifier does not support HTML 5. However, the plugin incorporates work to add new elements (e.g. article, section, video, mark) to the HTML definition, based on HTML 4.01 Transitional, so HTMLPurifier won't strip them. To enable this functionality, specify the Doctype as 'HTML 5' in your configuration.
 
 ##License
 

--- a/src/Model/Behavior/HtmlPurifierBehavior.php
+++ b/src/Model/Behavior/HtmlPurifierBehavior.php
@@ -71,13 +71,16 @@ class HtmlPurifierBehavior extends Behavior
                 $this->config($field, $config[$field], false);
             }
         }
+        
+        /* Ensure Definition ID is set for maybeGetRawHTMLDefinition() */
+        $definitionId = $this->config('config.HTML.DefinitionID') ?: 'purifiable';
+        $this->config('config.HTML.DefinitionID', $definitionId);
 
         /* Add custom HTML5 support, based on HTMLPurifier's HTML4 support */
         $html5 = ($this->config('config.HTML.Doctype') === 'HTML 5');
         if ($html5) {
             $this->config('config.HTML.Doctype', 'HTML 4.01 Transitional');
-            $defId = $this->config('config.HTML.DefinitionID');
-            $this->config('config.HTML.DefinitionID', $defId . '-html5');
+            $this->config('config.HTML.DefinitionID', $definitionId . '-html5');
         }
 
         /* Create config and populate */


### PR DESCRIPTION
Allow users to specify a Doctype "HTML 5" in addition to doctypes supported by HTMLPurifier.
Allow to change HTML definition in a method _editDefinition() that can be overwritten.
The base implementation of _editDefinition() adds basic HTML5 element support.